### PR TITLE
remove non-word

### DIFF
--- a/cmudict.dict
+++ b/cmudict.dict
@@ -96691,7 +96691,6 @@ puffy P AH1 F IY0
 pug P AH1 G
 puga P Y UW1 G AH0
 puget P Y UW1 JH IH0 T
-puget-1 P Y UW1 JH IH0 T W AH1 N
 pugh P Y UW1
 pugh's P Y UW1 Z
 pughs P Y UW1 Z


### PR DESCRIPTION
"puget-1" is not a word. Similar cleanup to https://github.com/cmusphinx/cmudict/commit/132be0d63ec0a6179d860114d7604e315541d94a#diff-549d1f460d1df1bb902e6a2570005ae7