### PR TITLE
In "t-shirt"(s), fix S -> SH transcription error

### DIFF
--- a/cmudict.dict
+++ b/cmudict.dict
@@ -119096,8 +119096,8 @@ t's T IY1 Z
 t-bone T IY1 B OW2 N
 t-lam T IY1 L AE1 M
 t-mobile T IY1 M OW1 B IY0 L
-t-shirt T IY1 S ER2 T
-t-shirts T IY1 S ER2 T S
+t-shirt T IY1 SH ER2 T
+t-shirts T IY1 SH ER2 T S
 t. T IY1
 t.'s T IY1 Z
 t.s T IY1 Z


### PR DESCRIPTION
`t-shirt` was originally transcribed `T IY1 S ER2 T`, but the 3rd phoneme ought to be `SH` rather than `S`. Fixed this for the plural as well.

Other `shirt` variants in the `cmudict.dict` file do not share this transcription error.

Just something I noticed while playing the daily [Heardle](https://heardle.glitch.me/) today.